### PR TITLE
fix: fix txt_path

### DIFF
--- a/image_datasets/dataset.py
+++ b/image_datasets/dataset.py
@@ -94,7 +94,7 @@ class CustomImageDataset(Dataset):
                 img = torch.load(os.path.join(self.img_cache_dir, self.images[idx].split('/')[-1] + '.pt'))
             else:
                 img = self.cached_image_embeddings[self.images[idx].split('/')[-1]]
-            txt_path = self.images[idx].split('.')[0] + '.' + self.caption_type
+            txt_path = self.images[idx].rsplit('.', 1)[0] + '.' + self.caption_type
             if self.cached_text_embeddings is None and self.txt_cache_dir is None:
                 prompt = open(txt_path).read()
                 if throw_one(self.caption_dropout_rate):


### PR DESCRIPTION
If imd_dir: is written as a relative path in the config file, the previous txt_path split method will cause errors in the txt file path because the relative path also contains'.' For example ./your_lora_dataset， This will result in the obtained txtpath being'. txt'
<img width="2260" height="608" alt="image" src="https://github.com/user-attachments/assets/3467b031-7e94-4e3b-be91-019dc2644da6" />
