### PR TITLE
Fix multi-GPU training crash due to undefined cache_dir

### DIFF
--- a/train_4090.py
+++ b/train_4090.py
@@ -139,6 +139,8 @@ def main():
         if accelerator.is_main_process:
             cache_dir = os.path.join(args.output_dir, "cache")
             os.makedirs(cache_dir, exist_ok=True)
+        accelerator.wait_for_everyone()
+        cache_dir = os.path.join(args.output_dir, "cache")
     if args.precompute_text_embeddings:
         with torch.no_grad():
             if args.save_cache_on_disk:

--- a/train_qwen_edit_lora.py
+++ b/train_qwen_edit_lora.py
@@ -154,6 +154,8 @@ def main():
         if accelerator.is_main_process:
             cache_dir = os.path.join(args.output_dir, "cache")
             os.makedirs(cache_dir, exist_ok=True)
+        accelerator.wait_for_everyone()
+        cache_dir = os.path.join(args.output_dir, "cache")
     if args.precompute_text_embeddings:
         with torch.no_grad():
             if args.save_cache_on_disk:


### PR DESCRIPTION
## Problem
When running multi-GPU training, non-main processes crash with `local variable 'cache_dir' referenced before assignment` because `cache_dir` is only defined within the `if accelerator.is_main_process:` block.

## Solution
Add two lines after the main process creates the cache directory:
1. `accelerator.wait_for_everyone()` - ensures the directory is created before other processes continue
2. `cache_dir = os.path.join(args.output_dir, "cache")` - defines the variable for all processes

## Changes
- Modified `train_4090.py`
- Modified `train_qwen_edit_lora.py`

## Testing
- ✅ Tested with single GPU - works as before
- ✅ Tested with multi-GPU - no longer crashes

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

## Impact
- Minimal change: Only 2 lines added per file
- No breaking changes: Single GPU training unchanged
- Enables proper multi-GPU training support